### PR TITLE
Transfer points command, fix restart when player is highlighted, and fix image upload

### DIFF
--- a/src/commands/animal_commands.py
+++ b/src/commands/animal_commands.py
@@ -88,12 +88,12 @@ class AnimalCommands(commands.Cog):
         """Adds an image to the 1/100 roll, use with the discord file system (and using .add image before) or by using .add image <url>"""
         if option == 'image':
             filepath = f"/assets/menno_dogs/{str(uuid.uuid4())}.jpg"
-            if ctx.message.attachments and ctx.message.attachments[0].url.lower().endswith(
+            if ctx.message.attachments and ctx.message.attachments[0].url.lower().split("?", 1)[0].endswith(
                     ('.png', '.jpg', '.jpeg', '.gif', '.webp')):
                 attachment_filename = ctx.message.attachments[0].filename
                 await ctx.message.attachments[0].save(filepath)  # doesnt work with relative paths
                 await ctx.send(f'Image added: {attachment_filename}')
-            elif args[-1].lower().endswith(('.png', '.jpg', '.jpeg', '.gif', '.webp')):
+            elif args[-1].lower().split("?", 1)[0].endswith(('.png', '.jpg', '.jpeg', '.gif', '.webp')):
                 try:
                     async with aiohttp.ClientSession() as session:
                         print(args[-1])

--- a/src/commands/commands_utility.py
+++ b/src/commands/commands_utility.py
@@ -54,3 +54,16 @@ def super_user_check(func):
             await ctx.send(f"Error occured during role check, Error: {e}")
             return
     return inner
+
+
+def fix_highlighted_player(main_db, betting_db, stalking_db):
+    active = stalking_db.get_active_user()
+    if active is None:
+        return
+    stalking_db.change_status(active, False)
+    all_bets = betting_db.get_all_bets()
+    for decision in all_bets.keys():
+        for user in all_bets[decision]:
+            main_db.increment_field(user['discord_id'], "points", int(user['amount']))
+            print(f"Refunding: {user['discord_id']}, {int(user['amount'])}")
+    betting_db.remove_all_bets()

--- a/src/commands/loop.py
+++ b/src/commands/loop.py
@@ -10,6 +10,7 @@ from databases.betting_db import BettingDB
 from databases.main_db import MainDB
 from databases.stalking_db import StalkingDB
 from commands.utility.end_image import EndImage
+from commands.commands_utility import fix_highlighted_player
 
 
 class loops(commands.Cog):
@@ -22,6 +23,8 @@ class loops(commands.Cog):
         self.channel_id: int = channel_id
         self.ping_role = ping_role
         self.active_message_id = 0
+        # Fix the db if there is a highlighted player
+        fix_highlighted_player(self.main_db, self.betting_db, self.stalking_db)
 
     @commands.Cog.listener()
     async def on_ready(self):

--- a/src/commands/point_commands.py
+++ b/src/commands/point_commands.py
@@ -196,6 +196,43 @@ class PointCommands(commands.Cog):
             print(ex)
             await ctx.send(ex)
 
+    @commands.command()
+    @role_check
+    async def transfer(self, ctx, *args):
+        """
+            Transfer your points to another player .transfer <@player> <points>
+        """
+        try:
+            print(f"Transfer command: {args}")
+            if len(args) != 2 or len(args[0]) < 3:
+                await ctx.send("Use .transfer <@player> <points>")
+                return
+            discord_id = bytes(args[0][2:-1], 'utf-8')
+            try:
+                points = int(args[1])
+            except ValueError:
+                await ctx.send("Use .transfer <@player> <points>")
+                return
+            all_players = self.main_db.get_all_users()
+            if discord_id not in all_players:
+                await ctx.send("User is not registered")
+                return
+            if points <= 0:
+                await ctx.send("Points must be larger than 0")
+                return
+            player_points = int(self.main_db.get_user_field(ctx.author.id, "points"))
+            if player_points < points:
+                await ctx.send("You do not have enough points")
+                return
+            self.main_db.decrement_field(ctx.author.id, "points", points)
+            self.main_db.increment_field(discord_id, "points", points)
+            embed = discord.Embed(title=f"Transferred {points} points", color=0xFF0000)
+            await ctx.send(embed=embed)
+        except Exception as e:
+            print(e)
+            await ctx.send(e)
+
+
 async def setup(bot):
     settings = Settings()
     main_db = MainDB(settings.REDISURL)


### PR DESCRIPTION
.transfer <@ player>  points
When the bot is restarted when a player is currently being highlighted, deactivate the highlight, refund and remove all the bets. No effect when there is no player being highlighted.
When an image is uploaded, either via attachments or link, split on the '?' to check if it is a proper image