### PR TITLE
Riot API rate limit implementation

### DIFF
--- a/src/commands/league_commands.py
+++ b/src/commands/league_commands.py
@@ -20,8 +20,8 @@ class LeagueCommands(riotAPI, commands.Cog):
     @commands.Cog.listener()
     async def on_ready(self):
         pass
-        
-        
+
+
     @commands.command()
     async def register(self, ctx, *args):
         """ Register a user by calling .register <your_league_name>"""
@@ -155,7 +155,7 @@ class LeagueCommands(riotAPI, commands.Cog):
                                       color=0xFF0000)
                 await ctx.send(embed=embed)
 
-                
+
     @commands.command()
     @role_check
     async def rank(self, ctx, *args):
@@ -263,6 +263,6 @@ async def setup(bot):
     settings = Settings()
     main_db = MainDB(settings.REDISURL)
     stalking_db = StalkingDB(settings.REDISURL)
-    riot_api = riotAPI(settings.RIOTTOKEN)
+    riot_api = riotAPI(settings.RIOTTOKEN, bot.get_tokenbucket())
     print("adding commands...")
     await bot.add_cog(LeagueCommands(main_db, stalking_db, riot_api, settings.PLAYERROLE, settings.GROLE, settings.JAILROLE))

--- a/src/commands/loop.py
+++ b/src/commands/loop.py
@@ -58,7 +58,7 @@ class loops(commands.Cog):
             for index, discord_id in enumerate(discord_ids):
                 riot_id = self.main_db.get_user_field(discord_id, "puuid")
                 try:
-                    flame_text = await self.riot_api.get_bad_kda_by_puuid(riot_id.decode('utf-8'), 5, sleep_time=10)
+                    flame_text = await self.riot_api.get_bad_kda_by_puuid(riot_id.decode('utf-8'), 5)
                 except aiohttp.ClientResponseError as e:
                     print(e.message)
                     await channel.send(e.message)
@@ -106,7 +106,7 @@ class loops(commands.Cog):
             for discord_id in discord_ids:
                 puuid = self.main_db.get_user_field(discord_id, "puuid")
                 tasks.append(self.riot_api.get_highest_damage_taken_by_puuid(puuid=puuid.decode('utf-8'), count=5,
-                                                                             sleep_time=delay, discord_id=discord_id))
+                                                                             discord_id=discord_id))
                 delay += 10
             try:
                 result = await asyncio.gather(*tasks)
@@ -141,7 +141,6 @@ class loops(commands.Cog):
                 try:
                     # Small 1 second delay to not spam the requests
                     print(pos_victim)
-                    await asyncio.sleep(1)
                     active, data, game_length, game_type = await self.riot_api.get_active_game_status(pos_victim)
                 except aiohttp.ClientResponseError as e:
                     print(e)
@@ -165,7 +164,7 @@ class loops(commands.Cog):
             async with channel.typing():
                 embed = discord.Embed(title=f":skull::skull:  {victim.upper()} IS IN GAME :skull::skull:\n"
                                             "YOU HAVE 10 MINUTES TO PREDICT!!!\n\n",
-                                      description="HE WILL SURELY WIN, RIGHT?",
+                                      description="THEY WILL SURELY WIN, RIGHT?",
                                       color=0xFF0000)
                 champions = [[player[1] for player in team] for team in data[1]]
                 players = [[player[0] for player in team] for team in data[1]]
@@ -308,6 +307,6 @@ async def setup(bot):
     main_db = MainDB(settings.REDISURL)
     betting_db = BettingDB(settings.REDISURL)
     stalking_db = StalkingDB(settings.REDISURL)
-    riot: riotAPI = riotAPI(settings.RIOTTOKEN)
+    riot: riotAPI = riotAPI(settings.RIOTTOKEN, bot.get_tokenbucket())
     print("adding loops..")
     await bot.add_cog(loops(bot, main_db, betting_db, stalking_db, riot, settings.CHANNELID, settings.PINGROLE))

--- a/src/commands/loop.py
+++ b/src/commands/loop.py
@@ -257,7 +257,7 @@ class loops(commands.Cog):
                 description = "**BELIEVERS WIN!!! HE HAS DONE IT AGAIN, THE 👑**\n"
                 winners = "believers"
             else:
-                description = "**DOUBTERS WIN!!! UNLUCKY, BUT SURELY NOT HIS FAULT 💀**\n"
+                description = "**DOUBTERS WIN!!! UNLUCKY, BUT SURELY NOT THEIR FAULT 💀**\n"
                 winners = "doubters"
 
             message: discord.Message = await channel.fetch_message(self.active_message_id)

--- a/src/commands/utility/bucket.py
+++ b/src/commands/utility/bucket.py
@@ -37,7 +37,6 @@ class TokenBucket:
         now = time.time()
         indx = self.bin_search(self._sliding_logs, now - self.window_duration)
         self._sliding_logs = self._sliding_logs[indx:]
-        # self._sliding_logs = [ts for ts in self._sliding_logs if ts > (now - self.window_duration)]
         return self._sliding_logs
 
     @sliding_logs.setter
@@ -58,9 +57,9 @@ class TokenBucket:
 
     async def request(self, url, params=None):
         while not self.can_consume(1):
-            print(f"TIMEOUT, WAITING: {self._tokens}, {len(self._sliding_logs)}")
+            # print(f"TIMEOUT, WAITING: {self._tokens}, {len(self._sliding_logs)}")
             time.sleep(1)
-        print("REQUEST SENT")
+        # print("REQUEST SENT")
         async with aiohttp.ClientSession() as session:
             async with session.get(url, params=params) as response:
                 response.raise_for_status()

--- a/src/commands/utility/bucket.py
+++ b/src/commands/utility/bucket.py
@@ -1,0 +1,67 @@
+import time
+import aiohttp
+
+
+class TokenBucket:
+    def __init__(self, max_tokens, fill_rate, window_size, window_duration):
+        self.capacity = max_tokens
+        self._tokens = max_tokens  # Start completely filled out
+        self.fill_rate = fill_rate
+        self.timestamp = time.time()
+        self._sliding_logs = []
+        self.window_size = window_size
+        self.window_duration = window_duration
+
+    def can_consume(self, tokens):
+        if tokens <= self.tokens and len(self.sliding_logs) < self.window_size:
+            self.tokens -= tokens
+            self.sliding_logs.append(time.time())
+            return True
+        return False
+
+    @property
+    def tokens(self):
+        if self._tokens < self.capacity:
+            now = time.time()
+            elapsed = now - self.timestamp
+            self._tokens = min(self.capacity, self._tokens + elapsed * self.fill_rate)
+            self.timestamp = now
+        return self._tokens
+
+    @tokens.setter
+    def tokens(self, num):
+        self._tokens = num
+
+    @property
+    def sliding_logs(self):
+        now = time.time()
+        indx = self.bin_search(self._sliding_logs, now - self.window_duration)
+        self._sliding_logs = self._sliding_logs[indx:]
+        # self._sliding_logs = [ts for ts in self._sliding_logs if ts > (now - self.window_duration)]
+        return self._sliding_logs
+
+    @sliding_logs.setter
+    def sliding_logs(self, arr):
+        self._sliding_logs = arr
+
+    def bin_search(self, arr, target):
+        start, end = 0, len(arr) - 1
+        while start <= end:
+            mid = (start + end) // 2
+            if arr[mid] <= target:
+                start = mid + 1
+            else:
+                if mid == 0 or arr[mid - 1] <= target:
+                    return mid
+                end = mid - 1
+        return 0
+
+    async def request(self, url, params=None):
+        while not self.can_consume(1):
+            print(f"TIMEOUT, WAITING: {self._tokens}, {len(self._sliding_logs)}")
+            time.sleep(1)
+        print("REQUEST SENT")
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, params=params) as response:
+                response.raise_for_status()
+                return await response.json()

--- a/src/discord_handler.py
+++ b/src/discord_handler.py
@@ -1,13 +1,13 @@
 import discord
-import datetime
-import requests
-from discord.ext import tasks, commands
+from discord.ext import commands
+from commands.utility.bucket import TokenBucket
 
 
 class discBot(commands.Bot):
     def __init__(self, token, channel_id) -> None:
         self.token = token
         self.CHANNEL_ID = channel_id
+        self.bucket = TokenBucket(20, 100 / 120, 100, 120)
         intents = discord.Intents.all()
         # intents.messages = True
         super().__init__(command_prefix='.', intents=intents)  # initialize the bot
@@ -19,6 +19,9 @@ class discBot(commands.Bot):
 
     async def start_bot(self):
         await self.start(self.token)
+
+    def get_tokenbucket(self):
+        return self.bucket
 
 
 async def add_cog(bot, files: list):


### PR DESCRIPTION
Allows a burst of 20 requests per second and 100 messages per 120 seconds. No need for any sleeps between the requests.